### PR TITLE
Add faraday-retry dependency and exclude vendor directory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source "https://rubygems.org"
 
 gem "github-pages", group: :jekyll_plugins
 gem "jekyll-include-cache", group: :jekyll_plugins
+gem "faraday-retry"

--- a/_config.yml
+++ b/_config.yml
@@ -111,3 +111,4 @@ exclude:
   - Gemfile.lock
   - tests
   - script
+  - vendor


### PR DESCRIPTION
## Summary
This PR adds the `faraday-retry` gem as a dependency and updates the Jekyll configuration to exclude the `vendor` directory from the build output.

## Changes
- Added `faraday-retry` gem to the Gemfile for HTTP request retry functionality
- Updated `_config.yml` to exclude the `vendor` directory from Jekyll's build process, preventing bundled dependencies from being included in the generated site

## Details
The `faraday-retry` gem provides automatic retry logic for HTTP requests made through the Faraday HTTP client library. Excluding the `vendor` directory from Jekyll's build ensures that locally bundled gems don't get processed or included in the final site output.

https://claude.ai/code/session_01TdAWQs8h97jpkLzR4krszf