### PR TITLE
Add repository field to _config.yml for github-metadata plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ description: >-
   Blog tecnico di Emanuele Garofalo.
   Articoli su .NET, C#, architettura software e sviluppo.
 url: "https://blog.unhandledexception.it"
+repository: "gar-ema/gar-ema.github.io"
 
 author:
   name: "Emanuele Garofalo"


### PR DESCRIPTION
The jekyll-github-metadata plugin requires the repository name to resolve baseurl and other GitHub-specific variables during CI builds. Without it, the build fails with "No repo name found".

https://claude.ai/code/session_01TdAWQs8h97jpkLzR4krszf