### PR TITLE
Refactor CI/CD: Deploy only on master branch pushes

### DIFF
--- a/.github/workflows/pages-deploy.yml
+++ b/.github/workflows/pages-deploy.yml
@@ -1,8 +1,6 @@
 name: "Build and Deploy"
 on:
   push:
-    branches:
-      - master
     paths-ignore:
       - .gitignore
       - README.md
@@ -53,6 +51,7 @@ jobs:
         run: python -m pytest tests/test_build.py -v
 
   deploy:
+    if: github.ref == 'refs/heads/master'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
Refactored the GitHub Actions workflow to decouple the build trigger from the deploy trigger, ensuring builds run on all branches while deployments only occur on the master branch.

## Key Changes
- Removed `branches: [master]` filter from the push trigger to allow builds on all branches
- Added conditional `if: github.ref == 'refs/heads/master'` to the deploy job to restrict deployments to master branch only
- Maintained existing `paths-ignore` configuration to skip builds for documentation and configuration files

## Implementation Details
This change enables CI/CD to run tests and build artifacts on feature branches and pull requests, while reserving actual deployments to GitHub Pages for the master branch only. This provides better visibility into build status across all branches without unnecessary deployment attempts.

https://claude.ai/code/session_01QjPcLY2P4MeJSunheWrVCR