### PR TITLE
Fix broken asset URLs by setting baseurl explicitly

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,7 @@ description: >-
   Blog tecnico di Emanuele Garofalo.
   Articoli su .NET, C#, architettura software e sviluppo.
 url: "https://blog.unhandledexception.it"
+baseurl: ""
 repository: "gar-ema/gar-ema.github.io"
 
 author:


### PR DESCRIPTION
When jekyll-github-metadata could not authenticate against the
GitHub API during build, it derived a wrong baseurl
(/pages/gar-ema), which broke every asset, navigation link,
canonical URL and feed reference (CSS/JS were loaded from
/pages/gar-ema/assets/... and returned 404, leaving the site
unstyled). Pin baseurl: "" in _config.yml so relative_url is
always anchored at the site root.